### PR TITLE
Add ruff preview rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ select = [
     "PLC",
     "PLE",
     "PLW",
+    "PT",
     "PYI",
     "Q",
     "RET",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,9 +76,7 @@ select = [
     "B",
     "BLE",
     "COM",
-    "CPY",
     "DJ",
-    "DOC",
     "E",
     "ERA",
     "EXE",
@@ -117,6 +115,7 @@ select = [
     "W",
     "YTT",
 ]
+preview = true
 
 [tool.pytest.ini_options]
 addopts = "-ra --strict-markers"

--- a/src/resfo_utilities/_rft_reader.py
+++ b/src/resfo_utilities/_rft_reader.py
@@ -252,12 +252,12 @@ class RFTReader(Iterable[RFTEntry]):
         if file_path.suffix == ".RFT":
             return cls(open(file_path, "rb"))
         if file_path.suffix == ".FRFT":
-            return cls(open(file_path))
+            return cls(open(file_path, encoding="utf-8"))
         basename = file_path.parent / file_path.stem
         if (f := basename.with_suffix(".RFT")).exists():
             return cls(open(f, "rb"))
         if (f := basename.with_suffix(".FRFT")).exists():
-            return cls(open(f))
+            return cls(open(f, encoding="utf-8"))
         raise FileNotFoundError(f"Could not find any RFT file matching '{file_like}'")
 
     def __iter__(self) -> Iterator[RFTEntry]:

--- a/src/resfo_utilities/testing/_egrid_generator.py
+++ b/src/resfo_utilities/testing/_egrid_generator.py
@@ -329,8 +329,12 @@ class EGrid:
             filelike: The egrid file to write to.
         """
         contents = []
-        contents.append(("FILEHEAD", self.file_head.to_egrid()))
-        contents.append(("GRIDUNIT", self.grid_unit.to_egrid()))  # type: ignore
+        contents.extend(
+            [
+                ("FILEHEAD", self.file_head.to_egrid()),
+                ("GRIDUNIT", self.grid_unit.to_egrid()),
+            ],
+        )  # type: ignore
         contents += self.global_grid.to_egrid()
         resfo.write(filelike, contents)
 

--- a/tests/integration/test_grid.py
+++ b/tests/integration/test_grid.py
@@ -2,7 +2,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-from pytest import approx
 
 from resfo_utilities import CornerpointGrid, MapAxes
 
@@ -18,74 +17,74 @@ def test_that_we_can_read_the_eightcells_grid_from_the_simulator(
 
     assert grid.coord.shape == (3, 3, 2, 3)
     assert grid.coord[0, 0].tolist() == [
-        approx([0.1, 0.2, 0.3]),
-        approx([0.4, 0.5, 100.6]),
+        pytest.approx([0.1, 0.2, 0.3]),
+        pytest.approx([0.4, 0.5, 100.6]),
     ]
     assert grid.coord[1, 0].tolist() == [
-        approx([50.7, 0.8, 0.9]),
-        approx([51.1, 1.2, 101.3]),
+        pytest.approx([50.7, 0.8, 0.9]),
+        pytest.approx([51.1, 1.2, 101.3]),
     ]
     assert grid.coord[2, 0].tolist() == [
-        approx([101.4, 1.5, 1.6]),
-        approx([101.7, 1.8, 101.9]),
+        pytest.approx([101.4, 1.5, 1.6]),
+        pytest.approx([101.7, 1.8, 101.9]),
     ]
     assert grid.coord[0, 1].tolist() == [
-        approx([2.0, 52.1, 2.3]),
-        approx([2.4, 52.5, 102.6]),
+        pytest.approx([2.0, 52.1, 2.3]),
+        pytest.approx([2.4, 52.5, 102.6]),
     ]
     assert grid.coord[1, 1].tolist() == [
-        approx([52.7, 52.8, 2.9]),
-        approx([53.0, 53.1, 103.2]),
+        pytest.approx([52.7, 52.8, 2.9]),
+        pytest.approx([53.0, 53.1, 103.2]),
     ]
     assert grid.coord[2, 1].tolist() == [
-        approx([103.3, 53.4, 3.5]),
-        approx([103.6, 53.7, 103.8]),
+        pytest.approx([103.3, 53.4, 3.5]),
+        pytest.approx([103.6, 53.7, 103.8]),
     ]
     assert grid.coord[0, 2].tolist() == [
-        approx([3.9, 104.0, 4.1]),
-        approx([4.2, 104.3, 104.4]),
+        pytest.approx([3.9, 104.0, 4.1]),
+        pytest.approx([4.2, 104.3, 104.4]),
     ]
     assert grid.coord[1, 2].tolist() == [
-        approx([54.5, 104.6, 4.7]),
-        approx([54.8, 104.9, 105.0]),
+        pytest.approx([54.5, 104.6, 4.7]),
+        pytest.approx([54.8, 104.9, 105.0]),
     ]
     assert grid.coord[2, 2].tolist() == [
-        approx([105.1, 105.2, 5.3]),
-        approx([105.4, 105.5, 105.6]),
+        pytest.approx([105.1, 105.2, 5.3]),
+        pytest.approx([105.4, 105.5, 105.6]),
     ]
 
     assert grid.zcorn.shape == (2, 2, 2, 8)
     # Order of heights for each corner is
     # (N(orth) means higher y, E(east) means higer x, T(op) means lower z (depth))
     # TSW TSE TNW TNE BSW BSE BNW BNE
-    assert grid.zcorn[0, 0, 0, :].tolist() == approx(
+    assert grid.zcorn[0, 0, 0, :].tolist() == pytest.approx(
         [0.0, 0.1, 0.4, 0.5, 50.0, 50.1, 50.4, 50.5],
     )
-    assert grid.zcorn[1, 0, 0, :].tolist() == approx(
+    assert grid.zcorn[1, 0, 0, :].tolist() == pytest.approx(
         [0.2, 0.3, 0.6, 0.7, 50.2, 50.3, 50.6, 50.7],
     )
-    assert grid.zcorn[0, 1, 0, :].tolist() == approx(
+    assert grid.zcorn[0, 1, 0, :].tolist() == pytest.approx(
         [0.8, 0.9, 1.2, 1.3, 50.8, 50.9, 51.2, 51.3],
     )
-    assert grid.zcorn[1, 1, 0, :].tolist() == approx(
+    assert grid.zcorn[1, 1, 0, :].tolist() == pytest.approx(
         [1.0, 1.1, 1.4, 1.5, 51.0, 51.1, 51.4, 51.5],
     )
-    assert grid.zcorn[0, 0, 1, :].tolist() == approx(
+    assert grid.zcorn[0, 0, 1, :].tolist() == pytest.approx(
         [51.6, 51.7, 52.0, 52.1, 100.0, 100.1, 100.4, 100.5],
     )
-    assert grid.zcorn[1, 0, 1, :].tolist() == approx(
+    assert grid.zcorn[1, 0, 1, :].tolist() == pytest.approx(
         [51.8, 51.9, 52.2, 52.3, 100.2, 100.3, 100.6, 100.7],
     )
-    assert grid.zcorn[0, 1, 1, :].tolist() == approx(
+    assert grid.zcorn[0, 1, 1, :].tolist() == pytest.approx(
         [52.4, 52.5, 52.8, 52.9, 100.8, 100.9, 101.2, 101.3],
     )
-    assert grid.zcorn[1, 1, 1, :].tolist() == approx(
+    assert grid.zcorn[1, 1, 1, :].tolist() == pytest.approx(
         [52.6, 52.7, 53.0, 53.1, 101.0, 101.1, 101.4, 101.5],
     )
     assert grid.map_axes == MapAxes(
-        y_axis=approx((0.01, 1.01)),
-        origin=approx((0.01, 0.01)),
-        x_axis=approx((1.01, 0.01)),
+        y_axis=pytest.approx((0.01, 1.01)),
+        origin=pytest.approx((0.01, 0.01)),
+        x_axis=pytest.approx((1.01, 0.01)),
     )
 
     assert grid.point_in_cell((25, 25, 25), 0, 0, 0)

--- a/tests/unit/test_summary_keys.py
+++ b/tests/unit/test_summary_keys.py
@@ -119,7 +119,7 @@ def test_inter_region_summary_format_contains_in_and_out_regions(keyword, name, 
 @given(name=valid_names)
 @pytest.mark.parametrize("keyword", ["BOPR", "BOSAT"])
 @pytest.mark.parametrize(
-    "nx,ny,number,indices",
+    ("nx", "ny", "number", "indices"),
     [
         (1, 1, 1, "1,1,1"),
         (2, 1, 2, "2,1,1"),
@@ -135,7 +135,7 @@ def test_block_summary_format_have_cell_index(keyword, number, indices, name, nx
 @given(name=valid_names)
 @pytest.mark.parametrize("keyword", ["COPR"])
 @pytest.mark.parametrize(
-    "nx,ny,number,indices",
+    ("nx", "ny", "number", "indices"),
     [
         (1, 1, 1, "1,1,1"),
         (2, 1, 2, "2,1,1"),
@@ -159,7 +159,7 @@ def test_completion_summary_format_have_cell_index_and_name(
 
 @pytest.mark.parametrize("keyword", ["LBWPR"])
 @pytest.mark.parametrize(
-    "li,lj,lk,lgr_name,indices",
+    ("li", "lj", "lk", "lgr_name", "indices"),
     [
         (1, 1, 1, "LGRNAME", "1,1,1"),
         (2, 1, 1, "LGRNAME", "2,1,1"),
@@ -185,7 +185,7 @@ def test_local_block_summary_format_have_cell_index_and_name(
 @given(name=valid_names, lgr_name=st.text())
 @pytest.mark.parametrize("keyword", ["LCOPR"])
 @pytest.mark.parametrize(
-    "li,lj,lk,indices",
+    ("li", "lj", "lk", "indices"),
     [
         (1, 1, 1, "1,1,1"),
         (2, 1, 1, "2,1,1"),
@@ -233,7 +233,7 @@ def test_is_rate_does_not_raise_error(key):
 
 @pytest.mark.parametrize(
     "opr_summary_variable",
-    ["FOPR", "FOPR", "GOPR", "WOPR", "COPR", "ROPR", "LCOPR"],
+    ["FOPR", "GOPR", "WOPR", "COPR", "ROPR", "LCOPR"],
 )
 def test_that_oil_production_rate_is_a_rate(opr_summary_variable):
     assert is_rate(opr_summary_variable)
@@ -241,7 +241,7 @@ def test_that_oil_production_rate_is_a_rate(opr_summary_variable):
 
 @pytest.mark.parametrize(
     "opt_summary_variable",
-    ["FOPT", "FOPT", "GOPT", "WOPT", "COPT", "ROPT", "LCOPT"],
+    ["FOPT", "GOPT", "WOPT", "COPT", "ROPT", "LCOPT"],
 )
 def test_that_oil_production_total_is_not_a_rate(opt_summary_variable):
     assert not is_rate(opt_summary_variable)
@@ -249,7 +249,7 @@ def test_that_oil_production_total_is_not_a_rate(opt_summary_variable):
 
 @pytest.mark.parametrize(
     "gpr_summary_variable",
-    ["FGPR", "FGPR", "GGPR", "WGPR", "CGPR", "RGPR", "LCGPR"],
+    ["FGPR", "GGPR", "WGPR", "CGPR", "RGPR", "LCGPR"],
 )
 def test_that_gas_production_rate_is_a_rate(gpr_summary_variable):
     assert is_rate(gpr_summary_variable)
@@ -257,7 +257,7 @@ def test_that_gas_production_rate_is_a_rate(gpr_summary_variable):
 
 @pytest.mark.parametrize(
     "opt_summary_variable",
-    ["FGPT", "FGPT", "GGPT", "WGPT", "CGPT", "RGPT", "LCGPT"],
+    ["FGPT", "GGPT", "WGPT", "CGPT", "RGPT", "LCGPT"],
 )
 def test_that_gas_production_total_is_not_a_rate(opt_summary_variable):
     assert not is_rate(opt_summary_variable)
@@ -265,7 +265,7 @@ def test_that_gas_production_total_is_not_a_rate(opt_summary_variable):
 
 @pytest.mark.parametrize(
     "gir_summary_variable",
-    ["FGIR", "FGIR", "GGIR", "WGIR", "CGIR", "RGIR", "LCGIR"],
+    ["FGIR", "GGIR", "WGIR", "CGIR", "RGIR", "LCGIR"],
 )
 def test_that_gas_injection_rate_is_a_rate(gir_summary_variable):
     assert is_rate(gir_summary_variable)
@@ -273,7 +273,7 @@ def test_that_gas_injection_rate_is_a_rate(gir_summary_variable):
 
 @pytest.mark.parametrize(
     "git_summary_variable",
-    ["FGIT", "FGIT", "GGIT", "WGIT", "CGIT", "RGIT", "LCGIT"],
+    ["FGIT", "GGIT", "WGIT", "CGIT", "RGIT", "LCGIT"],
 )
 def test_that_gas_injection_total_is_not_a_rate(git_summary_variable):
     assert not is_rate(git_summary_variable)
@@ -281,7 +281,7 @@ def test_that_gas_injection_total_is_not_a_rate(git_summary_variable):
 
 @pytest.mark.parametrize(
     "wpr_summary_variable",
-    ["FWPR", "FWPR", "GWPR", "WWPR", "CWPR", "RWPR", "LCWPR"],
+    ["FWPR", "GWPR", "WWPR", "CWPR", "RWPR", "LCWPR"],
 )
 def test_that_water_production_rate_is_a_rate(wpr_summary_variable):
     assert is_rate(wpr_summary_variable)
@@ -297,7 +297,7 @@ def test_that_water_production_total_is_not_a_rate(wpt_summary_variable):
 
 @pytest.mark.parametrize(
     "wir_summary_variable",
-    ["FWIR", "FWIR", "GWIR", "WWIR", "CWIR", "RWIR", "LCWIR"],
+    ["FWIR", "GWIR", "WWIR", "CWIR", "RWIR", "LCWIR"],
 )
 def test_that_water_injection_rate_is_a_rate(wir_summary_variable):
     assert is_rate(wir_summary_variable)
@@ -305,7 +305,7 @@ def test_that_water_injection_rate_is_a_rate(wir_summary_variable):
 
 @pytest.mark.parametrize(
     "wit_summary_variable",
-    ["FWIT", "FWIT", "GWIT", "WWIT", "CWIT", "RWIT", "LCWIT"],
+    ["FWIT", "GWIT", "WWIT", "CWIT", "RWIT", "LCWIT"],
 )
 def test_that_water_injection_total_is_not_a_rate(wit_summary_variable):
     assert not is_rate(wit_summary_variable)

--- a/tests/unit/test_summary_keys.py
+++ b/tests/unit/test_summary_keys.py
@@ -3,7 +3,9 @@ import pytest
 from hypothesis import given
 
 from resfo_utilities import SummaryKeyType, is_rate, make_summary_key
-from resfo_utilities.testing._summary_generator import _inter_region_summary_variables
+from resfo_utilities.testing._summary_generator import (
+    _inter_region_summary_variables,  # noqa: PLC2701
+)
 
 DUMMY_NAME = ":+:+:+:+"
 

--- a/tests/unit/test_summary_reader.py
+++ b/tests/unit/test_summary_reader.py
@@ -18,13 +18,13 @@ def test_that_summary_reader_can_be_initialized_with_either_path_or_io(tmp_path:
     (tmp_path / "CASE.FUNSMRY").touch()
     _ = SummaryReader(case_path=tmp_path / "CASE")
     _ = SummaryReader(smspec=StringIO, summaries=[StringIO])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must be initialized with either"):
         _ = SummaryReader(
             case_path=tmp_path,
             smspec=StringIO,
             summaries=[StringIO],
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must be initialized with either"):
         _ = SummaryReader()
 
 
@@ -80,7 +80,7 @@ def read_summary(smspec, unsmry, report_step_only=True):
 
 
 @pytest.mark.parametrize(
-    "spec_contents, smry_contents, error_message",
+    ("spec_contents", "smry_contents", "error_message"),
     [
         (b"", b"", "Keyword startdat missing"),
         (b"1", b"1", "Summary files contained invalid contents"),


### PR DESCRIPTION
    Resolve and enforce ruff preview rules
    
    Removing DOC and CPY which only applies in preview mode, and which we do
    not want to enforce.
