### PR TITLE
Add new data structure for point in cell search

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,79 @@
+name: Benchmarks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  python:
+    name: "Python benchmarks"
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --extra dev --extra testing
+
+      - name: Run benchmarks
+        run: uv run pytest tests/performance/ --benchmark-enable
+
+  cpp:
+    name: "C++ benchmarks"
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install ccache
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ccache
+
+      - name: Cache benchmark dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: build_bench/_deps
+          key: ${{ runner.os }}-bench-deps-${{ hashFiles('benchmarks/CMakeLists.txt', '.github/workflows/benchmarks.yml') }}
+
+      - name: Cache ccache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ccache
+          key: ${{ runner.os }}-ccache-${{ hashFiles('src/resfo_utilities/_cpp/**', 'benchmarks/*.cpp', 'benchmarks/*.hpp', 'benchmarks/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-
+
+
+      # Build with two jobs to limit memory pressure on runner
+      - name: Build benchmarks
+        run: |
+          cmake -S benchmarks -B build_bench -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake --build build_bench --parallel 2
+
+      - name: Run benchmarks
+        run: |
+          ./build_bench/bench_grid_search
+          ./build_bench/bench_bounding_boxes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ FetchContent_MakeAvailable(ceres)
 pybind11_add_module(_grid_cpp
     src/resfo_utilities/_cpp/bindings.cpp
     src/resfo_utilities/_cpp/grid_search.cpp
+    src/resfo_utilities/_cpp/column_interval_tree.cpp
     src/resfo_utilities/_cpp/point_in_cell.cpp
 )
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -62,6 +62,7 @@ set(CPP_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../src/resfo_utilities/_cpp)
 
 add_executable(bench_grid_search
     bench_grid_search.cpp
+    ${CPP_SRC}/column_interval_tree.cpp
     ${CPP_SRC}/point_in_cell.cpp
     ${CPP_SRC}/grid_search.cpp
 )

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -74,3 +74,16 @@ if(Eigen3_FOUND)
 else()
     target_link_libraries(bench_grid_search PRIVATE eigen ceres benchmark::benchmark)
 endif()
+
+add_executable(bench_bounding_boxes
+    bench_bounding_boxes.cpp
+    ${CPP_SRC}/column_interval_tree.cpp
+)
+
+target_include_directories(bench_bounding_boxes PRIVATE ${CPP_SRC} ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(Eigen3_FOUND)
+    target_link_libraries(bench_bounding_boxes PRIVATE Eigen3::Eigen benchmark::benchmark)
+else()
+    target_link_libraries(bench_bounding_boxes PRIVATE eigen benchmark::benchmark)
+endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 3.15)
+project(resfo_benchmarks LANGUAGES CXX)
+
+# This is a standalone CMake project so that benchmarks can be built
+# without Python, pybind11, or pip:
+#   cmake -S benchmarks -B build_bench -DCMAKE_BUILD_TYPE=Release
+#   cmake --build build_bench
+# Eigen and Ceres are redeclared here because the root CMakeLists.txt
+# requires Python/pybind11 which we want to avoid for benchmark builds.
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(FATAL_ERROR
+        "CMAKE_BUILD_TYPE is not set. Benchmarks require an explicit build type, e.g.:\n"
+        "  cmake -S benchmarks -B build_bench -DCMAKE_BUILD_TYPE=Release")
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(FetchContent)
+
+# Eigen
+find_package(Eigen3 3.4 QUIET NO_MODULE)
+if(NOT Eigen3_FOUND)
+    FetchContent_Declare(
+        Eigen
+        GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+        GIT_TAG 3147391d946bb4b6c68edd901f2add6ac1f31f8c # 3.4.0
+        GIT_SHALLOW TRUE
+    )
+    set(EIGEN_BUILD_DOC OFF CACHE BOOL "" FORCE)
+    set(EIGEN_BUILD_PKGCONFIG OFF CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(Eigen)
+endif()
+
+# Ceres (required by point_in_cell.cpp)
+FetchContent_Declare(
+    ceres
+    GIT_REPOSITORY https://github.com/ceres-solver/ceres-solver.git
+    GIT_TAG 85331393dc0dff09f6fb9903ab0c4bfa3e134b01 # 2.2.0
+    GIT_SHALLOW TRUE
+)
+set(MINIGLOG ON CACHE BOOL "" FORCE)
+set(BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+set(PROVIDE_UNINSTALL_TARGET OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(ceres)
+
+# Google Benchmark
+set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+    googlebenchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG v1.9.1
+    GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(googlebenchmark)
+
+set(CPP_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../src/resfo_utilities/_cpp)
+
+add_executable(bench_grid_search
+    bench_grid_search.cpp
+    ${CPP_SRC}/point_in_cell.cpp
+    ${CPP_SRC}/grid_search.cpp
+)
+
+target_include_directories(bench_grid_search PRIVATE ${CPP_SRC} ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(Eigen3_FOUND)
+    target_link_libraries(bench_grid_search PRIVATE Eigen3::Eigen ceres benchmark::benchmark)
+else()
+    target_link_libraries(bench_grid_search PRIVATE eigen ceres benchmark::benchmark)
+endif()

--- a/benchmarks/bench_bounding_boxes.cpp
+++ b/benchmarks/bench_bounding_boxes.cpp
@@ -1,0 +1,32 @@
+#include <benchmark/benchmark.h>
+#include <vector>
+
+#include "column_interval_tree.hpp"
+#include "grid.hpp"
+#include "bench_helpers.hpp"
+
+static void BM_CreateColumnBoundingBoxes(benchmark::State& state)
+{
+    const int ni = state.range(0);
+    const int nj = state.range(0);
+    const int nk = state.range(1);
+
+    std::vector<float> coord, zcorn;
+    make_grid_regular(ni, nj, nk, coord, zcorn);
+    resfo::GridDimensions dims{ni, nj, nk};
+
+    for (auto _ : state) {
+        auto boxes = resfo::create_column_bounding_boxes(coord.data(), dims, {0.0f, static_cast<float>(nk)});
+        benchmark::DoNotOptimize(boxes);
+    }
+
+    state.SetItemsProcessed(state.iterations() * ni * nj);
+}
+
+BENCHMARK(BM_CreateColumnBoundingBoxes)
+    ->Args({50, 10})
+    ->Args({50, 50})
+    ->Args({100, 10})
+    ->Args({100, 50});
+
+BENCHMARK_MAIN();

--- a/benchmarks/bench_grid_search.cpp
+++ b/benchmarks/bench_grid_search.cpp
@@ -1,0 +1,100 @@
+#include <benchmark/benchmark.h>
+#include <utility>
+#include <vector>
+
+#include "grid_search.hpp"
+#include "bench_helpers.hpp"
+
+using CellResult = std::optional<std::tuple<int, int, int>>;
+
+using PointSet = std::vector<Eigen::Vector3d>(*)(int, int, int, int, int);
+
+using GridFactory = void(*)(int, int, int, std::vector<float>&, std::vector<float>&);
+
+template<GridFactory MakeGrid, PointSet MakePoints>
+static void BM_GridSearch(benchmark::State& state)
+{
+    const int ni = state.range(0);
+    const int nj = state.range(0);
+    const int nk = state.range(1);
+    const int n_pts = state.range(2);
+    const int n_pts_outside = state.range(3);
+
+    std::vector<float> coord, zcorn;
+    MakeGrid(ni, nj, nk, coord, zcorn);
+    resfo::GridDimensions dims{ni, nj, nk};
+
+    auto points = MakePoints(ni, nj, nk, n_pts, n_pts_outside);
+
+    auto [z_min, z_max] = std::minmax_element(zcorn.begin(), zcorn.end());
+    auto top = resfo::pillar_z_intersection(coord.data(), dims, *z_min);
+    auto bot = resfo::pillar_z_intersection(coord.data(), dims, *z_max);
+
+    std::vector<CellResult> results;
+    results.reserve(points.size());
+    std::optional<std::pair<int, int>> prev_ij;
+
+    for (auto _ : state) {
+        for (const auto& p : points) {
+            auto r = resfo::grid_search(p, coord.data(), zcorn.data(), dims, top, bot, 1e-6f, prev_ij);
+            if (r.has_value())
+                results.push_back(std::make_tuple(r->i, r->j, r->k));
+            else
+                results.push_back(std::nullopt);
+
+            prev_ij = r ? std::make_optional(std::make_pair(r->i, r->j)) : std::nullopt;
+            benchmark::DoNotOptimize(r);
+        }
+    }
+    state.SetItemsProcessed(state.iterations() * n_pts);
+}
+
+// Register with given name and two grid depths (10 and 50 cells). All grids
+// have 50 cells in x- and y-direction.
+#define REGISTER_GRID_SEARCH_BENCHMARK(name, grid_fn, pts_fn, n_pts, n_pts_outside) \
+    BENCHMARK_TEMPLATE(BM_GridSearch, grid_fn, pts_fn)                              \
+        ->Name(name)                                                                \
+        ->Args({50, 10, n_pts, n_pts_outside})                                      \
+        ->Args({50, 50, n_pts, n_pts_outside})
+
+// All points inside
+REGISTER_GRID_SEARCH_BENCHMARK(
+    "BM_GridSearch/regular_grid/all_points_inside",
+    make_grid_regular, make_points_regular, 100, 0
+);
+REGISTER_GRID_SEARCH_BENCHMARK(
+    "BM_GridSearch/regular_grid/all_points_outside",
+    make_grid_regular, make_points_regular, 100, 100
+);
+REGISTER_GRID_SEARCH_BENCHMARK(
+    "BM_GridSearch/regular_grid/5_points_outside",
+    make_grid_regular, make_points_regular, 100, 5
+);
+
+REGISTER_GRID_SEARCH_BENCHMARK(
+    "BM_GridSearch/tilted_grid/all_points_inside",
+    make_grid_tilted, make_points_tilted, 100, 0
+);
+REGISTER_GRID_SEARCH_BENCHMARK(
+    "BM_GridSearch/tilted_grid/all_points_outside",
+    make_grid_tilted, make_points_tilted, 100, 100
+);
+REGISTER_GRID_SEARCH_BENCHMARK(
+    "BM_GridSearch/tilted_grid/5_points_outside",
+    make_grid_tilted, make_points_tilted, 100, 5
+);
+
+REGISTER_GRID_SEARCH_BENCHMARK(
+    "BM_GridSearch/faulted_grid/all_points_inside",
+    make_grid_faulted, make_points_faulted, 100, 0
+);
+REGISTER_GRID_SEARCH_BENCHMARK(
+    "BM_GridSearch/faulted_grid/all_points_outside",
+    make_grid_faulted, make_points_faulted, 100, 100
+);
+REGISTER_GRID_SEARCH_BENCHMARK(
+    "BM_GridSearch/faulted_grid/5_points_outside",
+    make_grid_faulted, make_points_faulted, 100, 5
+);
+
+BENCHMARK_MAIN();

--- a/benchmarks/bench_grid_search.cpp
+++ b/benchmarks/bench_grid_search.cpp
@@ -1,11 +1,10 @@
 #include <benchmark/benchmark.h>
-#include <utility>
 #include <vector>
 
 #include "grid_search.hpp"
+#include "column_interval_tree.hpp"
 #include "bench_helpers.hpp"
 
-using CellResult = std::optional<std::tuple<int, int, int>>;
 
 using PointSet = std::vector<Eigen::Vector3d>(*)(int, int, int, int, int);
 
@@ -24,25 +23,14 @@ static void BM_GridSearch(benchmark::State& state)
     MakeGrid(ni, nj, nk, coord, zcorn);
     resfo::GridDimensions dims{ni, nj, nk};
 
+    auto column_bboxes = resfo::create_column_bounding_boxes(coord.data(), dims, {0.0f, static_cast<float>(nk)});
+    resfo::ColumnIntervalTree tree(std::move(column_bboxes));
+
     auto points = MakePoints(ni, nj, nk, n_pts, n_pts_outside);
-
-    auto [z_min, z_max] = std::minmax_element(zcorn.begin(), zcorn.end());
-    auto top = resfo::pillar_z_intersection(coord.data(), dims, *z_min);
-    auto bot = resfo::pillar_z_intersection(coord.data(), dims, *z_max);
-
-    std::vector<CellResult> results;
-    results.reserve(points.size());
-    std::optional<std::pair<int, int>> prev_ij;
 
     for (auto _ : state) {
         for (const auto& p : points) {
-            auto r = resfo::grid_search(p, coord.data(), zcorn.data(), dims, top, bot, 1e-6f, prev_ij);
-            if (r.has_value())
-                results.push_back(std::make_tuple(r->i, r->j, r->k));
-            else
-                results.push_back(std::nullopt);
-
-            prev_ij = r ? std::make_optional(std::make_pair(r->i, r->j)) : std::nullopt;
+            auto r = resfo::grid_search(p, coord.data(), zcorn.data(), dims, tree, 1e-6f);
             benchmark::DoNotOptimize(r);
         }
     }

--- a/benchmarks/bench_helpers.hpp
+++ b/benchmarks/bench_helpers.hpp
@@ -1,0 +1,195 @@
+#pragma once
+
+#include <algorithm>
+#include <vector>
+#include <Eigen/Dense>
+
+// Tilt applied to every pillar in make_grid_tilted (units of x per unit of depth).
+static constexpr float TILT_FACTOR = 0.5f;
+
+// Fault throw applied to the downthrown block (j >= nj/2) in make_grid_faulted.
+static constexpr float FAULT_THROW = 5.0f;
+
+// ---------------------------------------------------------------------------
+// Grid factories
+// ---------------------------------------------------------------------------
+
+// Regular grid: vertical pillars, unit cell spacing, nk uniform layers.
+// coord layout: [(ni+1)*(nj+1)] pillars, each 6 floats [x,y,z_top, x,y,z_bot]
+// zcorn layout: [ni*nj*nk*8] corner depths
+inline void make_grid_regular(int ni, int nj, int nk,
+                      std::vector<float>& coord,
+                      std::vector<float>& zcorn)
+{
+    coord.resize((ni + 1) * (nj + 1) * 6);
+    for (int i = 0; i <= ni; ++i) {
+        for (int j = 0; j <= nj; ++j) {
+            int p = (i * (nj + 1) + j) * 6;
+            coord[p + 0] = static_cast<float>(i);
+            coord[p + 1] = static_cast<float>(j);
+            coord[p + 2] = 0.0f;
+            coord[p + 3] = static_cast<float>(i);
+            coord[p + 4] = static_cast<float>(j);
+            coord[p + 5] = static_cast<float>(nk);
+        }
+    }
+
+    zcorn.resize(ni * nj * nk * 8);
+    for (int i = 0; i < ni; ++i) {
+        for (int j = 0; j < nj; ++j) {
+            for (int k = 0; k < nk; ++k) {
+                int base = (i * nj * nk + j * nk + k) * 8;
+                float z_top = static_cast<float>(k);
+                float z_bot = static_cast<float>(k + 1);
+                for (int c = 0; c < 4; ++c) zcorn[base + c]     = z_top;
+                for (int c = 0; c < 4; ++c) zcorn[base + 4 + c] = z_bot;
+            }
+        }
+    }
+}
+
+// Tilted grid: pillars lean TILT_FACTOR units in +x per unit of depth.
+// At depth z the x position of pillar i is: i + TILT_FACTOR * z.
+// This causes pillar bounding boxes to overlap heavily in x, stressing 2D
+// spatial indices.
+inline void make_grid_tilted(int ni, int nj, int nk,
+                              std::vector<float>& coord,
+                              std::vector<float>& zcorn)
+{
+    coord.resize((ni + 1) * (nj + 1) * 6);
+    for (int i = 0; i <= ni; ++i) {
+        for (int j = 0; j <= nj; ++j) {
+            int p = (i * (nj + 1) + j) * 6;
+            coord[p + 0] = static_cast<float>(i);
+            coord[p + 1] = static_cast<float>(j);
+            coord[p + 2] = 0.0f;
+            coord[p + 3] = static_cast<float>(i) + TILT_FACTOR * nk;
+            coord[p + 4] = static_cast<float>(j);
+            coord[p + 5] = static_cast<float>(nk);
+        }
+    }
+
+    zcorn.resize(ni * nj * nk * 8);
+    for (int i = 0; i < ni; ++i) {
+        for (int j = 0; j < nj; ++j) {
+            for (int k = 0; k < nk; ++k) {
+                int base = (i * nj * nk + j * nk + k) * 8;
+                for (int c = 0; c < 4; ++c) zcorn[base + c]     = static_cast<float>(k);
+                for (int c = 0; c < 4; ++c) zcorn[base + 4 + c] = static_cast<float>(k + 1);
+            }
+        }
+    }
+}
+
+// Faulted grid: cells with j >= nj/2 are thrown down by FAULT_THROW in z.
+// The upthrown block (j < nj/2) has z in [k, k+1]; the downthrown block
+// (j >= nj/2) has z in [k + FAULT_THROW, k + 1 + FAULT_THROW].
+// Pillar z_bot spans the full range so no pillar is truncated.
+inline void make_grid_faulted(int ni, int nj, int nk,
+                               std::vector<float>& coord,
+                               std::vector<float>& zcorn)
+{
+    coord.resize((ni + 1) * (nj + 1) * 6);
+    for (int i = 0; i <= ni; ++i) {
+        for (int j = 0; j <= nj; ++j) {
+            int p = (i * (nj + 1) + j) * 6;
+            coord[p + 0] = static_cast<float>(i);
+            coord[p + 1] = static_cast<float>(j);
+            coord[p + 2] = 0.0f;
+            coord[p + 3] = static_cast<float>(i);
+            coord[p + 4] = static_cast<float>(j);
+            coord[p + 5] = static_cast<float>(nk) + FAULT_THROW; // spans both blocks
+        }
+    }
+
+    zcorn.resize(ni * nj * nk * 8);
+    for (int i = 0; i < ni; ++i) {
+        for (int j = 0; j < nj; ++j) {
+            float offset = (j >= nj / 2) ? FAULT_THROW : 0.0f;
+            for (int k = 0; k < nk; ++k) {
+                int base = (i * nj * nk + j * nk + k) * 8;
+                float z_top = static_cast<float>(k) + offset;
+                float z_bot = static_cast<float>(k + 1) + offset;
+                for (int c = 0; c < 4; ++c) zcorn[base + c]     = z_top;
+                for (int c = 0; c < 4; ++c) zcorn[base + 4 + c] = z_bot;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Point generators
+// ---------------------------------------------------------------------------
+
+// A set of query points scattered across a regular grid interior.
+inline std::vector<Eigen::Vector3d> make_points_regular(int ni, int nj, int nk, int n_pts, int n_pts_outside)
+{
+    std::vector<Eigen::Vector3d> pts;
+    pts.reserve(n_pts);
+    for (int idx = 0; idx < n_pts; ++idx) {
+        double fi = static_cast<double>(idx % ni) + 0.5;
+        double fj = static_cast<double>((idx / ni) % nj) + 0.5;
+        double fk = static_cast<double>((idx / (ni * nj)) % nk) + 0.5;
+        pts.emplace_back(fi, fj, fk);
+    }
+
+    // Shift points outside of the grid
+    const double x_shift = ni * 10.0;
+    const double y_shift = nj * 10.0;
+    const int n_pts_to_shift = std::clamp(n_pts_outside, 0, n_pts);
+    for (int i = 0; i < n_pts_to_shift; ++i) {
+        pts[i][0] += x_shift;
+        pts[i][1] += y_shift;
+    }
+
+    return pts;
+}
+
+
+// Points at the cell centres of the tilted grid.
+// At depth z = k + 0.5 the cell centre x is: ci + 0.5 + TILT_FACTOR * (k + 0.5).
+inline std::vector<Eigen::Vector3d> make_points_tilted(int ni, int nj, int nk, int n_pts, int n_pts_outside)
+{
+    std::vector<Eigen::Vector3d> pts;
+    pts.reserve(n_pts);
+    for (int idx = 0; idx < n_pts; ++idx) {
+        int ci = idx % ni;
+        int cj = (idx / ni) % nj;
+        int ck = (idx / (ni * nj)) % nk;
+        double fk = ck + 0.5;
+        double fx = ci + 0.5 + TILT_FACTOR * fk;
+        pts.emplace_back(fx, cj + 0.5, fk);
+    }
+
+    const double x_shift = (ni + TILT_FACTOR * nk) * 10.0;
+    const double y_shift = nj * 10.0;
+    const int n_pts_to_shift = std::clamp(n_pts_outside, 0, n_pts);
+    for (int i = 0; i < n_pts_to_shift; ++i) {
+        pts[i][0] += x_shift;
+        pts[i][1] += y_shift;
+    }
+    return pts;
+}
+
+// Points at the cell centres of the faulted grid (z accounts for fault throw).
+inline std::vector<Eigen::Vector3d> make_points_faulted(int ni, int nj, int nk, int n_pts, int n_pts_outside)
+{
+    std::vector<Eigen::Vector3d> pts;
+    pts.reserve(n_pts);
+    for (int idx = 0; idx < n_pts; ++idx) {
+        int ci = idx % ni;
+        int cj = (idx / ni) % nj;
+        int ck = (idx / (ni * nj)) % nk;
+        double offset = (cj >= nj / 2) ? FAULT_THROW : 0.0;
+        pts.emplace_back(ci + 0.5, cj + 0.5, ck + 0.5 + offset);
+    }
+
+    const double x_shift = ni * 10.0;
+    const double y_shift = nj * 10.0;
+    const int n_pts_to_shift = std::clamp(n_pts_outside, 0, n_pts);
+    for (int i = 0; i < n_pts_to_shift; ++i) {
+        pts[i][0] += x_shift;
+        pts[i][1] += y_shift;
+    }
+    return pts;
+}

--- a/src/resfo_utilities/_cpp/bindings.cpp
+++ b/src/resfo_utilities/_cpp/bindings.cpp
@@ -1,13 +1,16 @@
 #include <algorithm>
+#include <limits>
 #include <optional>
 #include <stdexcept>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
 
+#include "column_interval_tree.hpp"
 #include "grid_search.hpp"
 #include "point_in_cell.hpp"
 
@@ -54,10 +57,6 @@ static GridArrays validate_and_extract(
     };
 }
 
-static Eigen::Vector3d point_at(const float* points, size_t idx) {
-    return Eigen::Vector3f::Map(&points[idx * 3]).cast<double>();
-}
-
 using CellResult = std::optional<std::tuple<int, int, int>>;
 
 static CellResult to_result(const std::optional<resfo::CellIndex>& r) {
@@ -72,20 +71,23 @@ std::vector<CellResult> find_cells_containing_points(
 {
     auto g = validate_and_extract(points_array, coord_array, zcorn_array);
 
-    auto [z_min, z_max] = std::minmax_element(g.zcorn, g.zcorn + g.zcorn_size);
-    auto top = resfo::pillar_z_intersection(g.coord, g.dims, *z_min);
-    auto bot = resfo::pillar_z_intersection(g.coord, g.dims, *z_max);
+    if (g.num_points == 0) return std::vector<CellResult>();
+
+    auto build_interval_tree = [&g]() {
+        auto [z_min, z_max] = std::minmax_element(g.zcorn, g.zcorn + g.zcorn_size);
+        auto bboxes = resfo::create_column_bounding_boxes(g.coord, g.dims, {*z_min, *z_max});
+        return resfo::ColumnIntervalTree(std::move(bboxes));
+    };
 
     std::vector<CellResult> results;
     results.reserve(g.num_points);
-    std::optional<std::pair<int, int>> prev_ij;
 
+    auto tree = build_interval_tree();
+    Eigen::Map<const Eigen::Matrix3Xf> point_map(g.points, 3, g.num_points);
     for (size_t i = 0; i < g.num_points; ++i) {
         auto r = resfo::grid_search(
-            point_at(g.points, i), g.coord, g.zcorn, g.dims, top, bot, tolerance, prev_ij);
-
+            point_map.col(i).cast<double>(), g.coord, g.zcorn, g.dims, tree, tolerance);
         results.push_back(to_result(r));
-        prev_ij = r ? std::make_optional(std::make_pair(r->i, r->j)) : std::nullopt;
     }
     return results;
 }
@@ -101,9 +103,10 @@ py::array_t<bool> point_in_cell_wrapper(
     auto result_buf = result.request();
     bool* result_ptr = static_cast<bool*>(result_buf.ptr);
 
+    Eigen::Map<const Eigen::Matrix3Xf> point_map(g.points, 3, g.num_points);
     for (size_t idx = 0; idx < g.num_points; ++idx) {
         result_ptr[idx] = resfo::point_in_cell(
-            point_at(g.points, idx), i, j, k, g.coord, g.zcorn, g.dims, tolerance);
+            point_map.col(idx).cast<double>(), i, j, k, g.coord, g.zcorn, g.dims, tolerance);
     }
     return result;
 }

--- a/src/resfo_utilities/_cpp/bindings.cpp
+++ b/src/resfo_utilities/_cpp/bindings.cpp
@@ -1,125 +1,110 @@
+#include <algorithm>
+#include <optional>
+#include <stdexcept>
+#include <tuple>
+#include <vector>
+
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
+
 #include "grid_search.hpp"
 #include "point_in_cell.hpp"
+
 #include <Eigen/Dense>
 namespace py = pybind11;
 
-std::vector<std::optional<std::tuple<int, int, int>>> find_cells_containing_points(
-    py::array_t<float, py::array::c_style | py::array::forcecast> points_array,
-    py::array_t<float, py::array::c_style | py::array::forcecast> coord_array,
-    py::array_t<float, py::array::c_style | py::array::forcecast> zcorn_array,
-    float tolerance) {
+using FloatArray = py::array_t<float, py::array::c_style | py::array::forcecast>;
 
+// Validated grid arrays extracted from numpy buffers.
+struct GridArrays {
+    const float* points;
+    const float* coord;
+    const float* zcorn;
+    resfo::GridDimensions dims;
+    size_t num_points;
+    size_t zcorn_size;
+};
+
+static GridArrays validate_and_extract(
+    FloatArray& points_array, FloatArray& coord_array, FloatArray& zcorn_array)
+{
     auto points_buf = points_array.request();
-    auto coord_buf = coord_array.request();
-    auto zcorn_buf = zcorn_array.request();
+    auto coord_buf  = coord_array.request();
+    auto zcorn_buf  = zcorn_array.request();
 
-    if (points_buf.ndim != 2 || points_buf.shape[1] != 3) {
+    if (points_buf.ndim != 2 || points_buf.shape[1] != 3)
         throw std::runtime_error("Points array must have shape (n, 3)");
-    }
-
-    if (coord_buf.ndim != 4 || coord_buf.shape[2] != 2 || coord_buf.shape[3] != 3) {
+    if (coord_buf.ndim != 4 || coord_buf.shape[2] != 2 || coord_buf.shape[3] != 3)
         throw std::runtime_error("Coord array must have shape (ni+1, nj+1, 2, 3)");
-    }
-
-    if (zcorn_buf.ndim != 4 || zcorn_buf.shape[3] != 8) {
+    if (zcorn_buf.ndim != 4 || zcorn_buf.shape[3] != 8)
         throw std::runtime_error("Zcorn array must have shape (ni, nj, nk, 8)");
-    }
 
-    const float* points = static_cast<const float*>(points_buf.ptr);
-    const float* coord = static_cast<const float*>(coord_buf.ptr);
-    const float* zcorn = static_cast<const float*>(zcorn_buf.ptr);
-
-    auto zcorn_shape = zcorn_buf.shape;
-    resfo::GridDimensions dims{
-        static_cast<int>(zcorn_shape[0]),
-        static_cast<int>(zcorn_shape[1]),
-        static_cast<int>(zcorn_shape[2])
+    return GridArrays{
+        static_cast<const float*>(points_buf.ptr),
+        static_cast<const float*>(coord_buf.ptr),
+        static_cast<const float*>(zcorn_buf.ptr),
+        resfo::GridDimensions{
+            static_cast<int>(zcorn_buf.shape[0]),
+            static_cast<int>(zcorn_buf.shape[1]),
+            static_cast<int>(zcorn_buf.shape[2])
+        },
+        static_cast<size_t>(points_buf.shape[0]),
+        static_cast<size_t>(zcorn_buf.size)
     };
+}
 
-    auto [z_min, z_max] = std::minmax_element(zcorn, zcorn + zcorn_buf.size);
+static Eigen::Vector3d point_at(const float* points, size_t idx) {
+    return Eigen::Vector3f::Map(&points[idx * 3]).cast<double>();
+}
 
-    auto top_intersection = resfo::pillar_z_intersection(coord, dims, *z_min);
-    auto bot_intersection = resfo::pillar_z_intersection(coord, dims, *z_max);
+using CellResult = std::optional<std::tuple<int, int, int>>;
 
-    size_t num_points = points_buf.shape[0];
-    std::vector<std::optional<std::tuple<int, int, int>>> results;
-    results.reserve(num_points);
+static CellResult to_result(const std::optional<resfo::CellIndex>& r) {
+    if (r.has_value())
+        return std::make_tuple(r->i, r->j, r->k);
+    return std::nullopt;
+}
+
+std::vector<CellResult> find_cells_containing_points(
+    FloatArray points_array, FloatArray coord_array, FloatArray zcorn_array,
+    float tolerance)
+{
+    auto g = validate_and_extract(points_array, coord_array, zcorn_array);
+
+    auto [z_min, z_max] = std::minmax_element(g.zcorn, g.zcorn + g.zcorn_size);
+    auto top = resfo::pillar_z_intersection(g.coord, g.dims, *z_min);
+    auto bot = resfo::pillar_z_intersection(g.coord, g.dims, *z_max);
+
+    std::vector<CellResult> results;
+    results.reserve(g.num_points);
     std::optional<std::pair<int, int>> prev_ij;
 
-    for (size_t p_idx = 0; p_idx < num_points; ++p_idx) {
-        Eigen::Vector3d p{
-            points[p_idx * 3],
-            points[p_idx * 3 + 1],
-            points[p_idx * 3 + 2]
-        };
+    for (size_t i = 0; i < g.num_points; ++i) {
+        auto r = resfo::grid_search(
+            point_at(g.points, i), g.coord, g.zcorn, g.dims, top, bot, tolerance, prev_ij);
 
-        auto result = resfo::grid_search(
-            p, coord, zcorn, dims, top_intersection, bot_intersection, tolerance,
-            prev_ij);
-
-        if (result.has_value()) {
-            results.push_back(std::make_tuple(result->i, result->j, result->k));
-            prev_ij = std::make_pair(result->i, result->j);
-        } else {
-            results.push_back(std::nullopt);
-            prev_ij = std::nullopt;
-        }
+        results.push_back(to_result(r));
+        prev_ij = r ? std::make_optional(std::make_pair(r->i, r->j)) : std::nullopt;
     }
     return results;
 }
 
 py::array_t<bool> point_in_cell_wrapper(
-    py::array_t<float, py::array::c_style | py::array::forcecast> points_array,
-    int i, int j, int k,
-    py::array_t<float, py::array::c_style | py::array::forcecast> coord_array,
-    py::array_t<float, py::array::c_style | py::array::forcecast> zcorn_array,
-    float tolerance) {
+    FloatArray points_array, int i, int j, int k,
+    FloatArray coord_array, FloatArray zcorn_array,
+    float tolerance)
+{
+    auto g = validate_and_extract(points_array, coord_array, zcorn_array);
 
-    auto points_buf = points_array.request();
-    auto coord_buf = coord_array.request();
-    auto zcorn_buf = zcorn_array.request();
-
-    if (points_buf.ndim != 2 || points_buf.shape[1] != 3) {
-        throw std::runtime_error("Points array must have shape (n, 3)");
-    }
-
-    if (coord_buf.ndim != 4 || coord_buf.shape[2] != 2 || coord_buf.shape[3] != 3) {
-        throw std::runtime_error("Coord array must have shape (ni+1, nj+1, 2, 3)");
-    }
-
-    if (zcorn_buf.ndim != 4 || zcorn_buf.shape[3] != 8) {
-        throw std::runtime_error("Zcorn array must have shape (ni, nj, nk, 8)");
-    }
-
-    const float* points = static_cast<const float*>(points_buf.ptr);
-    const float* coord = static_cast<const float*>(coord_buf.ptr);
-    const float* zcorn = static_cast<const float*>(zcorn_buf.ptr);
-
-    auto zcorn_shape = zcorn_buf.shape;
-    resfo::GridDimensions dims{
-        static_cast<int>(zcorn_shape[0]),
-        static_cast<int>(zcorn_shape[1]),
-        static_cast<int>(zcorn_shape[2])
-    };
-
-    size_t num_points = points_buf.shape[0];
-    auto result = py::array_t<bool>(num_points);
+    auto result = py::array_t<bool>(g.num_points);
     auto result_buf = result.request();
     bool* result_ptr = static_cast<bool*>(result_buf.ptr);
 
-    for (size_t p_idx = 0; p_idx < num_points; ++p_idx) {
-        Eigen::Vector3d p{
-            points[p_idx * 3],
-            points[p_idx * 3 + 1],
-            points[p_idx * 3 + 2]
-        };
-
-        result_ptr[p_idx] = resfo::point_in_cell(p, i, j, k, coord, zcorn, dims, tolerance);
+    for (size_t idx = 0; idx < g.num_points; ++idx) {
+        result_ptr[idx] = resfo::point_in_cell(
+            point_at(g.points, idx), i, j, k, g.coord, g.zcorn, g.dims, tolerance);
     }
-
     return result;
 }
 

--- a/src/resfo_utilities/_cpp/column_interval_tree.cpp
+++ b/src/resfo_utilities/_cpp/column_interval_tree.cpp
@@ -1,0 +1,179 @@
+#include "column_interval_tree.hpp"
+
+#include <array>
+#include <algorithm>
+#include <cmath>
+
+namespace resfo {
+
+// Compute (x, y) bounding boxes for each column by interpolating the four
+// corner pillars at the zcorn depth range. Pillars are lines in 3D space, so
+// the (x, y) extent of a column varies with depth. Using the full zcorn
+// z-range ensures the bounding boxes enclose the pillar positions across the
+// entire grid depth.
+std::vector<ColumnBoundingBox> create_column_bounding_boxes(const float* coord,
+                                                            const resfo::GridDimensions& dims,
+                                                            const std::pair<float, float>& z_minmax) {
+    std::vector<ColumnBoundingBox> boxes;
+    boxes.reserve(dims.ni * dims.nj);
+    const auto& [z_min, z_max] = z_minmax;
+
+    for (int i = 0; i < dims.ni; ++i) {
+        for (int j = 0; j < dims.nj; ++j) {
+            const std::array<int, 4> pillar_idx{
+                (i * (dims.nj + 1) + j) *  6,
+                (i * (dims.nj + 1) + (j + 1)) * 6,
+                ((i + 1) * (dims.nj + 1) + j) * 6,
+                ((i + 1) * (dims.nj + 1) + (j + 1)) * 6
+            };
+
+            ColumnBoundingBox box;
+            box.cell_index = {i, j, 0};
+
+            auto update_bounds = [&box](const std::pair<float, float>& xy) {
+                const auto& [x, y] = xy;
+                box.min_x = std::min(box.min_x, x);
+                box.max_x = std::max(box.max_x, x);
+                box.min_y = std::min(box.min_y, y);
+                box.max_y = std::max(box.max_y, y);
+            };
+
+            for (int v = 0; v < 4; ++v) {
+                int idx = pillar_idx[v];
+
+                float x1 = coord[idx];
+                float y1 = coord[idx + 1];
+                float z1 = coord[idx + 2];
+                float x2 = coord[idx + 3];
+                float y2 = coord[idx + 4];
+                float z2 = coord[idx + 5];
+
+                // Check difference to avoid division by close-to-zero numbers
+                float dz = z2 - z1;
+                if (std::abs(dz) <= std::numeric_limits<float>::epsilon() * std::max(std::abs(z1), std::abs(z2))) {
+                    update_bounds({x1, y1});
+                    continue;
+                }
+
+                auto pillar_x_y_at = [&](float z) {
+                    float t = (z - z1) / dz;
+                    float x = x1 + t * (x2 - x1);
+                    float y = y1 + t * (y2 - y1);
+                    return std::pair<float, float>{x, y};
+                };
+
+                update_bounds(pillar_x_y_at(z_min));
+                update_bounds(pillar_x_y_at(z_max));
+            }
+
+            boxes.push_back(std::move(box));
+        }
+    }
+
+    return boxes;
+}
+
+
+// When transposed_ is true, the x and y fields in each ColumnBoundingBox
+// have been swapped so that the primary tree axis is always "x".
+int ColumnIntervalTree::build(std::vector<ColumnBoundingBox> boxes) {
+    if (boxes.empty()) return -1;
+
+    // Midpoint = median of all interval midpoints to keep the tree balanced.
+    std::vector<float> mids;
+    mids.reserve(boxes.size());
+    for (const auto& b : boxes)
+        mids.push_back((b.min_x + b.max_x) * 0.5f);
+    std::nth_element(mids.begin(), mids.begin() + mids.size() / 2, mids.end());
+    float mid = mids[mids.size() / 2];
+
+    std::vector<ColumnBoundingBox> left_boxes, right_boxes, spanning;
+    for (auto& b : boxes) {
+        if (b.max_x < mid)      left_boxes.push_back(std::move(b));
+        else if (b.min_x > mid) right_boxes.push_back(std::move(b));
+        else                    spanning.push_back(std::move(b));
+    }
+    // All content has been moved out of boxes by now, but clear to avoid
+    // accidental access to moved content.
+    boxes.clear();
+
+    int idx = static_cast<int>(nodes_.size());
+    nodes_.emplace_back();
+    nodes_[idx].mid    = mid;
+    // Make one copy of the spanning set because we need two sets sorted by
+    // different keys for efficient querying.
+    nodes_[idx].by_min = spanning;
+    nodes_[idx].by_max = std::move(spanning);
+    std::sort(nodes_[idx].by_min.begin(), nodes_[idx].by_min.end(),
+              [](const auto& a, const auto& b) { return a.min_x < b.min_x; });
+    std::sort(nodes_[idx].by_max.begin(), nodes_[idx].by_max.end(),
+              [](const auto& a, const auto& b) { return a.max_x > b.max_x; });
+
+    nodes_[idx].left  = build(std::move(left_boxes));
+    nodes_[idx].right = build(std::move(right_boxes));
+    return idx;
+}
+
+// x and y here refer to the (possibly transposed) coordinates stored in each
+// ColumnBoundingBox — see build() and the constructor for details.
+void ColumnIntervalTree::query_node(int idx, float x, float y, float tol,
+                                    std::vector<std::pair<int,int>>& results) const {
+    if (idx == -1) return;
+    const Node& node = nodes_[idx];
+
+    if (x <= node.mid) {
+        // All spanning intervals have max_x >= mid >= x, so containment in X reduces
+        // to min_x <= x + tol. The list is sorted by min_x ascending: stop at first miss.
+        for (const auto& b : node.by_min) {
+            if (b.min_x > x + tol) break;
+            if (b.overlaps_y(y, tol))
+                 results.emplace_back(b.cell_index.i, b.cell_index.j);
+        }
+        query_node(node.left, x, y, tol, results);
+    } else {
+        // All spanning intervals have min_x <= mid < x, so containment in X reduces
+        // to max_x >= x - tol. The list is sorted by max_x descending: stop at first miss.
+        for (const auto& b : node.by_max) {
+            if (b.max_x < x - tol) break;
+            if (b.overlaps_y(y, tol))
+                results.emplace_back(b.cell_index.i, b.cell_index.j);
+        }
+        query_node(node.right, x, y, tol, results);
+    }
+}
+
+ColumnIntervalTree::ColumnIntervalTree(std::vector<ColumnBoundingBox> boxes) {
+    if (boxes.empty()) return;
+
+    // Choose the primary tree axis as whichever has the smaller total bbox
+    // extent — this minimises the size of spanning sets and therefore the
+    // number of candidates that reach the secondary-axis linear scan.
+    // For a tilted grid (lean in x), x-extents grow with tilt*depth while
+    // y-extents stay unit-width, so building on y is much more efficient.
+    float sum_x = 0.f, sum_y = 0.f;
+    for (const auto& b : boxes) {
+        sum_x += b.max_x - b.min_x;
+        sum_y += b.max_y - b.min_y;
+    }
+    transposed_ = (sum_y < sum_x);
+    if (transposed_) {
+        for (auto& b : boxes) {
+            std::swap(b.min_x, b.min_y);
+            std::swap(b.max_x, b.max_y);
+        }
+    }
+
+    nodes_.reserve(boxes.size());
+    build(std::move(boxes));
+}
+
+std::vector<std::pair<int,int>> ColumnIntervalTree::query(float x, float y, float tolerance) const {
+    std::vector<std::pair<int,int>> results;
+    if (nodes_.empty()) return results;
+    // Swap coordinates to match the axis the tree was built on.
+    if (transposed_) std::swap(x, y);
+    query_node(0, x, y, tolerance, results);
+    return results;
+}
+
+}  // namespace resfo

--- a/src/resfo_utilities/_cpp/column_interval_tree.hpp
+++ b/src/resfo_utilities/_cpp/column_interval_tree.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <limits>
+#include <utility>
+#include <vector>
+
+#include "grid.hpp"
+
+namespace resfo {
+
+// Bounding box of a column of cells defined by four pillars of the corner-point
+// grid.
+struct ColumnBoundingBox {
+    resfo::CellIndex cell_index;
+
+    float min_y = std::numeric_limits<float>::max();
+    float min_x = std::numeric_limits<float>::max();
+
+    float max_y = std::numeric_limits<float>::lowest();
+    float max_x = std::numeric_limits<float>::lowest();
+
+    bool overlaps_y(float y, float tol = 1e-6f) const {
+        return (min_y - tol <= y && y <= max_y + tol);
+    }
+};
+
+std::vector<ColumnBoundingBox> create_column_bounding_boxes(
+    const float* coord,
+    const resfo::GridDimensions& dims,
+    const std::pair<float, float>& z_minmax
+);
+
+// 1D interval tree over ColumnBoundingBox with secondary-axis filtering.
+//
+// The X dimension is indexed with a classic interval tree (O(log n + k')
+// stabbing query); each candidate is then filtered by Y containment. This
+// works best under the assumption that the overlap of the pillar bounding
+// boxes is small. If the bounding boxes' overlap is large, e.g. if the pillars
+// are heavily tilted, the query of the ColumnIntervalTree degrades to a
+// brute-force approach.
+class ColumnIntervalTree {
+private:
+    struct Node {
+        float mid;
+        // Spanning intervals sorted by primary-axis min ascending  (used when
+        // query <= mid).
+        std::vector<ColumnBoundingBox> by_min;
+        // Spanning intervals sorted by primary-axis max descending (used when
+        // query >  mid).
+        std::vector<ColumnBoundingBox> by_max;
+
+        // Indices of left and right child nodes in the nodes_ vector, or -1
+        // for no child.
+        int left  = -1;
+        int right = -1;
+    };
+
+    // Stores the tree structure in a vector for cache efficiency. The root
+    // node is at index 0.
+    std::vector<Node> nodes_;
+    // When true the tree is built on the Y axis (x and y coords are swapped in
+    // the stored bboxes).  The query() method swaps its x,y arguments before
+    // descending the tree and the results are returned with (i,j) unmodified.
+    bool transposed_ = false;
+
+    // Returns index of the root node, or -1 for an empty tree.
+    int build(std::vector<ColumnBoundingBox> boxes);
+    void query_node(int idx, float x, float y, float tol,
+                    std::vector<std::pair<int,int>>& results) const;
+
+public:
+    ColumnIntervalTree() = default;
+    explicit ColumnIntervalTree(std::vector<ColumnBoundingBox> boxes);
+
+    // Returns (i,j) indices of all pillar columns whose bounding box contains
+    // (x,y).
+    std::vector<std::pair<int,int>> query(float x, float y,
+                                          float tolerance = 1.e-6f) const;
+};
+
+}  // namespace resfo

--- a/src/resfo_utilities/_cpp/grid.hpp
+++ b/src/resfo_utilities/_cpp/grid.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace resfo {
+
+constexpr int NUM_CORNERS = 8;
+
+struct GridDimensions {
+    int ni;
+    int nj;
+    int nk;
+};
+
+struct CellIndex {
+    int i;
+    int j;
+    int k;
+};
+
+} /* namespace resfo */

--- a/src/resfo_utilities/_cpp/grid_search.cpp
+++ b/src/resfo_utilities/_cpp/grid_search.cpp
@@ -1,80 +1,143 @@
 #include "grid_search.hpp"
 
-#include <unordered_set>
-#include <queue>
+#include <array>
+#include <limits>
 #include <vector>
-#include <functional>
 
 #include "point_in_cell.hpp"
 
 namespace resfo {
 
+struct Candidate {
+    int i, j, k;
+    float z_dist;
+};
+
+// Gather candidate cells from the given columns, filtering by z-range.
+static std::vector<Candidate> gather_z_candidates(
+    const std::vector<std::pair<int, int>>& columns,
+    const float* zcorn, const GridDimensions& dims,
+    float pz, float bound_tol)
+{
+    std::vector<Candidate> candidates;
+    candidates.reserve(columns.size() * 2);
+
+    for (const auto& [ci, cj] : columns) {
+        for (int k = 0; k < dims.nk; ++k) {
+            int zcorn_idx = (ci * dims.nj * dims.nk + cj * dims.nk + k) * NUM_CORNERS;
+            auto [z_min_it, z_max_it] = std::minmax_element(
+                zcorn + zcorn_idx, zcorn + zcorn_idx + NUM_CORNERS);
+            if (pz >= *z_min_it - 2 * bound_tol && pz <= *z_max_it + 2 * bound_tol) {
+                float z_center = (*z_min_it + *z_max_it) * 0.5f;
+                candidates.emplace_back(Candidate{ci, cj, k, std::abs(z_center - pz)});
+            }
+        }
+    }
+
+    std::sort(candidates.begin(), candidates.end(),
+              [](const Candidate& a, const Candidate& b) { return a.z_dist < b.z_dist; });
+    return candidates;
+}
+
+// Test candidates in z-distance order, returning the first match.
+static std::optional<CellIndex> test_candidates(
+    const std::vector<Candidate>& candidates,
+    const Eigen::Vector3d& p, const float* coord, const float* zcorn,
+    const GridDimensions& dims, float tolerance)
+{
+    for (const auto& c : candidates) {
+        if (resfo::point_in_cell(p, c.i, c.j, c.k, coord, zcorn, dims, tolerance)) {
+            return CellIndex{c.i, c.j, c.k};
+        }
+    }
+    return std::nullopt;
+}
+
+// Order candidate columns by distance from the (x,y) bounding box at query
+// depth. Each column is defined by 4 pillars; we interpolate their (x,y) at
+// the query z and compute how far the point lies from the resulting bbox.
+// Columns are sorted by this distance so that the most likely hits are tested
+// first. No column is discarded — the trilinear cell interior can extend
+// beyond the pillar-corner bounding box at a given depth.
+static void order_columns_by_depth_distance(
+    std::vector<std::pair<int, int>>& columns,
+    const float* coord, const GridDimensions& dims,
+    float px, float py, float pz, float tol)
+{
+    std::vector<std::pair<float, int>> distances;
+    distances.reserve(columns.size());
+
+    for (int idx = 0; idx < static_cast<int>(columns.size()); ++idx) {
+        const auto& [ci, cj] = columns[idx];
+        const std::array<int, 4> pillar_idx = {
+            (ci * (dims.nj + 1) + cj) * 6,
+            (ci * (dims.nj + 1) + (cj + 1)) * 6,
+            ((ci + 1) * (dims.nj + 1) + cj) * 6,
+            ((ci + 1) * (dims.nj + 1) + (cj + 1)) * 6
+        };
+
+        float min_x = std::numeric_limits<float>::max();
+        float max_x = std::numeric_limits<float>::lowest();
+        float min_y = std::numeric_limits<float>::max();
+        float max_y = std::numeric_limits<float>::lowest();
+
+        for (int v = 0; v < 4; ++v) {
+            int base = pillar_idx[v];
+            float z_top = coord[base + 2];
+            float z_bot = coord[base + 5];
+
+            float dz = z_bot - z_top;
+            float x_at_z, y_at_z;
+            if (std::abs(dz) <= std::numeric_limits<float>::epsilon() * std::max(std::abs(z_top), std::abs(z_bot))) {
+                x_at_z = coord[base];
+                y_at_z = coord[base + 1];
+            } else {
+                float t = (pz - z_top) / dz;
+                x_at_z = coord[base]     + t * (coord[base + 3] - coord[base]);
+                y_at_z = coord[base + 1] + t * (coord[base + 4] - coord[base + 1]);
+            }
+
+            min_x = std::min(min_x, x_at_z);
+            max_x = std::max(max_x, x_at_z);
+            min_y = std::min(min_y, y_at_z);
+            max_y = std::max(max_y, y_at_z);
+        }
+
+        float dx = std::max(0.f, min_x - tol - px) + std::max(0.f, px - max_x - tol);
+        float dy = std::max(0.f, min_y - tol - py) + std::max(0.f, py - max_y - tol);
+        distances.push_back({dx + dy, idx});
+    }
+
+    std::sort(distances.begin(), distances.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+
+    std::vector<std::pair<int, int>> sorted;
+    sorted.reserve(columns.size());
+    for (const auto& [_, idx] : distances) {
+        sorted.push_back(columns[idx]);
+    }
+    columns = std::move(sorted);
+}
+
 std::optional<CellIndex> grid_search(
     const Eigen::Vector3d& p, const float* coord, const float* zcorn, const GridDimensions& dims,
-    const std::vector<float>& top, const std::vector<float>& bot, float tolerance,
-    std::optional<std::pair<int, int>> prev_ij) {
+    const ColumnIntervalTree& tree, float tolerance) {
 
-    float bound_tol = 20.0*tolerance;
+    float bound_tol = 20.0f * tolerance;
 
-    if (dims.ni <= 0 || dims.nj <= 0) {
+    if (dims.ni <= 0 || dims.nj <= 0 || dims.nk <= 0) {
         return std::nullopt;
     }
 
-    auto intersection = pillar_z_intersection(coord, dims, p[2]);
+    auto columns = tree.query(static_cast<float>(p[0]), static_cast<float>(p[1]), bound_tol);
+    order_columns_by_depth_distance(
+        columns, coord, dims,
+        static_cast<float>(p[0]), static_cast<float>(p[1]), static_cast<float>(p[2]),
+        bound_tol);
 
-    std::priority_queue<QuadNode, std::vector<QuadNode>, std::greater<QuadNode>> queue;
-    std::unordered_set<std::pair<int, int>, PairHash> visited;
-
-    if (prev_ij.has_value()) {
-        queue.emplace(prev_ij->first, prev_ij->second, p, 1, 1, intersection, dims);
-    } else {
-        queue.emplace(dims.ni / 2, dims.nj / 2, p, dims.ni / 2, dims.nj / 2, intersection,
-                      dims);
-    }
-
-    visited.insert({queue.top().i, queue.top().j});
-
-    while (!queue.empty()) {
-        QuadNode node = queue.top();
-        queue.pop();
-
-        int i = node.i;
-        int j = node.j;
-
-        float dist_from_bounds = distance_from_bounds(p, top, bot, i, j, dims);
-        if (dist_from_bounds <= 2 * bound_tol) {
-            for (int k = 0; k < dims.nk; ++k) {
-                int zcorn_idx = (i * dims.nj * dims.nk + j * dims.nk + k) * NUM_CORNERS;
-                auto [z_min, z_max] = std::minmax_element(zcorn + zcorn_idx, zcorn + zcorn_idx + NUM_CORNERS);
-
-                if (p[2] >= *z_min - 2 * bound_tol && p[2] <= *z_max + 2 * bound_tol) {
-                    if (resfo::point_in_cell(p, i, j, k, coord, zcorn, dims, tolerance)) {
-                        return CellIndex{i, j, k};
-                    }
-                }
-            }
-        }
-
-        int size_i = node.i_neighbourhood;
-        for (int di : {-1 * size_i, -1, 0, 1, size_i}) {
-            int ni = i + di;
-            if (ni < 0 || ni >= dims.ni) continue;
-
-            int size_j = node.j_neighbourhood;
-            for (int dj : {-1 * size_j, -1, 0, 1, size_j}) {
-                int nj = j + dj;
-                if (nj < 0 || nj >= dims.nj) continue;
-
-                if (visited.find({ni, nj}) == visited.end()) {
-                    queue.emplace(ni, nj, p, std::max(size_i / 2, 1), std::max(size_j / 2, 1),
-                                  intersection, dims);
-                    visited.insert({ni, nj});
-                }
-            }
-        }
-    }
-
-    return std::nullopt;
+    const float pz = static_cast<float>(p[2]);
+    auto candidates = gather_z_candidates(columns, zcorn, dims, pz, bound_tol);
+    return test_candidates(candidates, p, coord, zcorn, dims, tolerance);
 }
 
 }  // namespace resfo

--- a/src/resfo_utilities/_cpp/grid_search.hpp
+++ b/src/resfo_utilities/_cpp/grid_search.hpp
@@ -117,8 +117,8 @@ inline float distance_from_bounds(const Eigen::Vector3d& p, const std::vector<fl
     auto [min_x, max_x] = std::minmax_element(vertices_x.begin(), vertices_x.end());
     auto [min_y, max_y] = std::minmax_element(vertices_y.begin(), vertices_y.end());
 
-    float x_dist = std::max({*min_x - p[0], p[0] - *max_x, 0.0});
-    float y_dist = std::max({*min_y - p[1], p[1] - *max_y, 0.0});
+    float x_dist = std::max({*min_x - static_cast<float>(p[0]), static_cast<float>(p[0]) - *max_x, 0.0f});
+    float y_dist = std::max({*min_y - static_cast<float>(p[1]), static_cast<float>(p[1]) - *max_y, 0.0f});
 
     return x_dist + y_dist;
 }

--- a/src/resfo_utilities/_cpp/grid_search.hpp
+++ b/src/resfo_utilities/_cpp/grid_search.hpp
@@ -1,119 +1,16 @@
 #pragma once
 
-#include <cmath>
 #include <optional>
-#include <vector>
-#include <algorithm>
-#include <array>
 
 #include <Eigen/Dense>
 
+#include "column_interval_tree.hpp"
 #include "grid.hpp"
 
 namespace resfo {
 
-struct PairHash {
-    std::size_t operator()(const std::pair<int, int>& p) const {
-        return std::hash<int>()(p.first) ^ (std::hash<int>()(p.second) << 1);
-    }
-};
-
-/* The GridSearch algorithm is a search of QuadNodes. Each QuadNode describes a
- * pillar at (i,j) in the grid (see the docstring CornerpointGrid). The QuadNodes
- * are visited in order of a heuristic. This heuristic is calculated by first
- * finding the intersection of the plane z=p[2] and the pillars. This gives
- * a quad Q(i,j). The heuristic is the manhattan distance from p to center(Q(i,j)).
- */
-class QuadNode {
-public:
-    int i;
-    int j;
-    Eigen::Vector3d p;
-    int i_neighbourhood;
-    int j_neighbourhood;
-    float distance;
-
-    QuadNode(int i_, int j_, const Eigen::Vector3d& p_, int i_neigh, int j_neigh,
-             const std::vector<float>& intersection, const GridDimensions& dims)
-        : i(i_), j(j_), p(p_), i_neighbourhood(i_neigh), j_neighbourhood(j_neigh) {
-        distance = distance_intersection_center(intersection, dims);
-    }
-
-    bool operator>(const QuadNode& other) const {
-        return distance > other.distance;
-    }
-
-private:
-    /* The distance from p to Q(i,j). */
-    float distance_intersection_center(const std::vector<float>& intersection,
-                                       const GridDimensions& dims) const {
-        int idx_00 = (i * (dims.nj + 1) + j) * 2;
-        int idx_10 = ((i + 1) * (dims.nj + 1) + j) * 2;
-        int idx_11 = ((i + 1) * (dims.nj + 1) + (j + 1)) * 2;
-        int idx_01 = (i * (dims.nj + 1) + (j + 1)) * 2;
-
-        float center_x = (intersection[idx_00] + intersection[idx_10] +
-                          intersection[idx_11] + intersection[idx_01]) * 0.25f;
-        float center_y = (intersection[idx_00 + 1] + intersection[idx_10 + 1] +
-                          intersection[idx_11 + 1] + intersection[idx_01 + 1]) * 0.25f;
-
-        return std::abs(center_x - p[0]) + std::abs(center_y - p[1]);
-    }
-};
-
-/* The intersection of the pillars defined by coord and the plane z*/
-inline std::vector<float> pillar_z_intersection(
-    const float* coord, const GridDimensions& dims, float z) {
-    int num_pillars = (dims.ni + 1) * (dims.nj + 1);
-    std::vector<float> result(2*num_pillars);
-
-    for (int idx = 0; idx < num_pillars; ++idx) {
-        int base = idx * 6;
-        float x1 = coord[base];
-        float y1 = coord[base + 1];
-        float z1 = coord[base + 2];
-        float x2 = coord[base + 3];
-        float y2 = coord[base + 4];
-        float z2 = coord[base + 5];
-
-        float t = (z - z1) / (z2 - z1);
-        result[idx*2] = x1 + t * (x2 - x1);
-        result[idx*2+1] = y1 + t * (y2 - y1);
-    }
-
-    return result;
-}
-
-inline float distance_from_bounds(const Eigen::Vector3d& p, const std::vector<float>& top,
-                                  const std::vector<float>& bot, int i, int j,
-                                  const GridDimensions& dims) {
-    int idx_00 = (i * (dims.nj + 1) + j) * 2;
-    int idx_10 = ((i + 1) * (dims.nj + 1) + j) * 2;
-    int idx_11 = ((i + 1) * (dims.nj + 1) + (j + 1)) * 2;
-    int idx_01 = (i * (dims.nj + 1) + (j + 1)) * 2;
-
-
-    std::array<float, NUM_CORNERS> vertices_x{
-        top[idx_00],     top[idx_10],     top[idx_11],     top[idx_01],
-        bot[idx_00],     bot[idx_10],     bot[idx_11],     bot[idx_01]
-    };
-    std::array<float, NUM_CORNERS> vertices_y{
-        top[idx_00 + 1], top[idx_10 + 1], top[idx_11 + 1], top[idx_01 + 1],
-        bot[idx_00 + 1], bot[idx_10 + 1], bot[idx_11 + 1], bot[idx_01 + 1]
-    };
-
-    auto [min_x, max_x] = std::minmax_element(vertices_x.begin(), vertices_x.end());
-    auto [min_y, max_y] = std::minmax_element(vertices_y.begin(), vertices_y.end());
-
-    float x_dist = std::max({*min_x - static_cast<float>(p[0]), static_cast<float>(p[0]) - *max_x, 0.0f});
-    float y_dist = std::max({*min_y - static_cast<float>(p[1]), static_cast<float>(p[1]) - *max_y, 0.0f});
-
-    return x_dist + y_dist;
-}
-
 std::optional<CellIndex> grid_search(
     const Eigen::Vector3d& p, const float* coord, const float* zcorn, const GridDimensions& dims,
-    const std::vector<float>& top, const std::vector<float>& bot, float tolerance,
-    std::optional<std::pair<int, int>> prev_ij);
+    const ColumnIntervalTree& tree, float tolerance);
 
 }  // namespace resfo

--- a/src/resfo_utilities/_cpp/grid_search.hpp
+++ b/src/resfo_utilities/_cpp/grid_search.hpp
@@ -8,21 +8,9 @@
 
 #include <Eigen/Dense>
 
+#include "grid.hpp"
+
 namespace resfo {
-
-const int NUM_CORNERS = 8;
-
-struct GridDimensions {
-    int ni;
-    int nj;
-    int nk;
-};
-
-struct CellIndex {
-    int i;
-    int j;
-    int k;
-};
 
 struct PairHash {
     std::size_t operator()(const std::pair<int, int>& p) const {

--- a/tests/performance/test_find_cell_performance.py
+++ b/tests/performance/test_find_cell_performance.py
@@ -5,27 +5,132 @@ import pytest
 
 from resfo_utilities import CornerpointGrid
 
+TILT_FACTOR = 0.5
+FAULT_THROW = 5.0
+
+# Grid factories produce unit-cell grids (each cell is 1x1x1) so that test
+# point coordinates are easy to reason about. Total grid depth equals nk.
+
+
+def _make_regular_grid(ni, nj, nk):
+    coord = np.zeros((ni + 1, nj + 1, 2, 3), dtype=np.float32)
+    zcorn = np.zeros((ni, nj, nk, 8), dtype=np.float32)
+    for i, j in product(range(ni + 1), range(nj + 1)):
+        coord[i, j, 0] = [i, j, 0.0]
+        coord[i, j, 1] = [i, j, float(nk)]
+    for i, j, k in product(range(ni), range(nj), range(nk)):
+        zcorn[i, j, k] = [k] * 4 + [k + 1] * 4
+    return coord, zcorn
+
+
+def _make_tilted_grid(ni, nj, nk):
+    """Pillars lean TILT_FACTOR units in +x per unit of depth."""
+    coord = np.zeros((ni + 1, nj + 1, 2, 3), dtype=np.float32)
+    zcorn = np.zeros((ni, nj, nk, 8), dtype=np.float32)
+    for i, j in product(range(ni + 1), range(nj + 1)):
+        coord[i, j, 0] = [i, j, 0.0]
+        coord[i, j, 1] = [i + TILT_FACTOR * nk, j, float(nk)]
+    for i, j, k in product(range(ni), range(nj), range(nk)):
+        zcorn[i, j, k] = [k] * 4 + [k + 1] * 4
+    return coord, zcorn
+
+
+def _make_faulted_grid(ni, nj, nk):
+    """Cells with j >= nj//2 are thrown down by FAULT_THROW in z."""
+    coord = np.zeros((ni + 1, nj + 1, 2, 3), dtype=np.float32)
+    zcorn = np.zeros((ni, nj, nk, 8), dtype=np.float32)
+    for i, j in product(range(ni + 1), range(nj + 1)):
+        coord[i, j, 0] = [i, j, 0.0]
+        coord[i, j, 1] = [i, j, float(nk) + FAULT_THROW]
+    for i, j, k in product(range(ni), range(nj), range(nk)):
+        offset = FAULT_THROW if j >= nj // 2 else 0.0
+        zcorn[i, j, k] = [k + offset] * 4 + [k + 1 + offset] * 4
+    return coord, zcorn
+
 
 @pytest.fixture
 def large_regular_grid():
     ni, nj, nk = 50, 50, 10
-    height = 100
-    top_depth = 0.0
-    bot_depth = top_depth + height
-    coord = np.zeros((ni + 1, nj + 1, 2, 3), dtype=np.float32)
-    zcorn = np.zeros((ni, nj, nk, 8), dtype=np.float32)
-    for i, j in product(range(ni + 1), range(nj + 1)):
-        coord[i, j, 0] = [i, j, top_depth]
-        coord[i, j, 1] = [i, j, bot_depth]
-    for i, j, k in product(range(ni), range(nj), range(nk)):
-        zcorn[i, j, k] = [height * (k / nk)] * 4 + [height * ((k + 1) / nk)] * 4
+    coord, zcorn = _make_regular_grid(ni, nj, nk)
     return CornerpointGrid(coord, zcorn)
 
 
-def test_benchmark_find_cell(large_regular_grid, benchmark):
+@pytest.fixture
+def large_tilted_grid():
+    ni, nj, nk = 50, 50, 10
+    coord, zcorn = _make_tilted_grid(ni, nj, nk)
+    return CornerpointGrid(coord, zcorn)
+
+
+@pytest.fixture
+def large_faulted_grid():
+    ni, nj, nk = 50, 50, 10
+    coord, zcorn = _make_faulted_grid(ni, nj, nk)
+    return CornerpointGrid(coord, zcorn)
+
+
+def test_benchmark_find_cell_regular_points_inside(large_regular_grid, benchmark):
     def run():
         assert large_regular_grid.find_cell_containing_point(
-            [(i + 25.5, j + 25.5, 20.5) for i, j in product(range(10), range(10))],
+            [(i + 25.5, j + 25.5, 2.5) for i, j in product(range(10), range(10))],
         ) == [(i + 25, j + 25, 2) for i, j in product(range(10), range(10))]
+
+    benchmark(run)
+
+
+def test_benchmark_find_cell_regular_points_outside(large_regular_grid, benchmark):
+    def run():
+        assert large_regular_grid.find_cell_containing_point(
+            [(i + 125.5, j + 125.5, 20.5) for i, j in product(range(10), range(10))],
+        ) == [None for i, j in product(range(10), range(10))]
+
+    benchmark(run)
+
+
+def test_benchmark_find_cell_tilted_points_inside(large_tilted_grid, benchmark):
+    def run():
+        pts = [
+            (i + 25.5 + TILT_FACTOR * 2.5, j + 25.5, 2.5)
+            for i, j in product(range(10), range(10))
+        ]
+        results = large_tilted_grid.find_cell_containing_point(pts)
+        assert all(r is not None for r in results)
+
+    benchmark(run)
+
+
+def test_benchmark_find_cell_tilted_points_outside(large_tilted_grid, benchmark):
+    x_shift = (50 + TILT_FACTOR * 10) * 10
+    pts = [(x_shift + i, j + 25.5, 2.5) for i, j in product(range(10), range(10))]
+
+    def run():
+        assert large_tilted_grid.find_cell_containing_point(
+            pts,
+        ) == [None for _ in pts]
+
+    benchmark(run)
+
+
+def test_benchmark_find_cell_faulted_points_inside(large_faulted_grid, benchmark):
+    pts = [(i + 25.5, j + 20.5, 2.5) for i, j in product(range(5), range(5))] + [
+        (i + 25.5, j + 25.5, 2.5 + FAULT_THROW) for i, j in product(range(5), range(5))
+    ]
+
+    def run():
+        results = large_faulted_grid.find_cell_containing_point(
+            pts,
+        )
+        assert all(r is not None for r in results)
+
+    benchmark(run)
+
+
+def test_benchmark_find_cell_faulted_points_outside(large_faulted_grid, benchmark):
+    pts = [(i + 125.5, j + 125.5, 20.5) for i, j in product(range(10), range(10))]
+
+    def run():
+        assert large_faulted_grid.find_cell_containing_point(
+            pts,
+        ) == [None for _ in pts]
 
     benchmark(run)

--- a/tests/unit/test_cornerpoint_grid.py
+++ b/tests/unit/test_cornerpoint_grid.py
@@ -5,7 +5,7 @@ import hypothesis.strategies as st
 import numpy as np
 import pytest
 import resfo
-from hypothesis import assume, example, given
+from hypothesis import HealthCheck, assume, example, given, settings
 from hypothesis.extra.numpy import arrays, from_dtype
 from numpy.testing import assert_allclose
 
@@ -525,6 +525,7 @@ def test_that_point_in_cell_correctly_assign_vertices_to_faces():
     assert grid.find_cell_containing_point(point) == [(0, 0, 0)]
 
 
+@settings(suppress_health_check=[HealthCheck.filter_too_much])
 @given(*([st.floats(min_value=-1.0, max_value=2.0)] * 3))
 @pytest.mark.parametrize(
     "bottom_heights",
@@ -567,12 +568,12 @@ def test_point_in_cell_considers_cells_as_trilinear_shapes(bottom_heights, x, y,
     def in_bounding_box(point):
         return all(-1 * tolerance <= c <= 1 + tolerance for c in point)
 
-    # avoid points that is very close to the boundary to avoid
-    # numerical issues
+    # avoid points that are very close to the boundary to avoid
+    # numerical issues with the nonlinear solver
     assume(np.abs(z) >= 0.01)
     assume(np.abs(bottom_face_depth(x, y) - z) >= 0.01)
-    assume(np.abs(x - 1) >= 0.01 or np.abs(x + 1) >= 0.01)
-    assume(np.abs(y - 1) >= 0.01 or np.abs(y + 1) >= 0.01)
+    assume(np.abs(x) >= 0.01 and np.abs(x - 1) >= 0.01)
+    assume(np.abs(y) >= 0.01 and np.abs(y - 1) >= 0.01)
 
     # only the bottom face is different from the bounding box
     # so containment is the same as the conjunction of the two conditions

--- a/tests/unit/test_cornerpoint_grid.py
+++ b/tests/unit/test_cornerpoint_grid.py
@@ -788,6 +788,32 @@ def single_cell_grids(draw):
     ),
     point=(0.0, 0.0, 9.999999747378752e-06),
 ).via("discovered failure")
+@example(
+    grid=CornerpointGrid(
+        coord=np.array(
+            [
+                [
+                    [[0.0, -4.0, 0.0], [0.0, 4.0, 1.0]],
+                    [[1.0, -1.0, 0.0], [1.0, 1.0, 2.0]],
+                ],
+                [
+                    [[1.0, 10.0, 0.0], [1.0, 10.0, 1.0]],
+                    [[0.0, 10.0, 0.0], [0.0, 10.0, 1.0]],
+                ],
+            ],
+            dtype=np.float32,
+        ),
+        zcorn=np.array(
+            [[[[0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 1.0]]]],
+            dtype=np.float32,
+        ),
+        map_axes=None,
+    ),
+    point=(0.528, -0.7, 0.5),
+).via(
+    "Discussed as counter-example in review."
+    "Point in cell, but not in xy-bounding box at z",
+)
 def test_that_in_single_cell_grids_found_and_contains_are_the_same(
     grid: CornerpointGrid,
     point: tuple[float, float, float],


### PR DESCRIPTION
The PR aims to improve the performance of `point_in_cell`. The main focus is to quickly identify points that are clearly outside of the corner point grid and thus cannot be in any cell.

## About the commits

1. The first two commits add some general changes and fixes. They resolve a test (need feedback if this looks correct) and some compiler warnings.
2. Afterwards, we refactor the existing code slightly to make it easier to integrate the interval tree.
3. Add additional benchmarks. This should allow the reviewer to pick a commit, run the benchmarks and then go to another commit, run the benchmarks, and compare the performance.
4. Implementation of the interval tree.
5. Replacing the current `grid_search` with the interval tree.
6. Optional: Integrate benchmarks into GitHub Action. We can integrate it with Codspeed, but this should maybe go into another PR as this will need some reconfiguration of the repository as far as I understand.

## Issue

This PR is connected to a spike without issue so we cannot link to it.